### PR TITLE
"alicia_d_leader" is missing from teleop.type, and "teleop.directly_controls_robot" support is missing from lerobot-teleoperate

### DIFF
--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -161,8 +161,11 @@ def teleop_loop(
         # Process action for robot through pipeline
         robot_action_to_send = robot_action_processor((teleop_action, obs))
 
-        # Send processed action to robot (robot_action_processor.to_output should return dict[str, Any])
-        _ = robot.send_action(robot_action_to_send)
+        # When the teleoperator controls the robot through a direct hardware
+        # connection, sending the action again from the computer would duplicate
+        # the command. Keep processing it for visualization, but skip transmission.
+        if not teleop.directly_controls_robot:
+            _ = robot.send_action(robot_action_to_send)
 
         if display_data:
             # Process robot observation through pipeline

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -85,6 +85,7 @@ from lerobot.robots import (  # noqa: F401
 from lerobot.teleoperators import (  # noqa: F401
     Teleoperator,
     TeleoperatorConfig,
+    alicia_d_leader,
     bi_so100_leader,
     gamepad,
     homunculus,

--- a/tests/test_control_robot.py
+++ b/tests/test_control_robot.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from lerobot.scripts.lerobot_calibrate import CalibrateConfig, calibrate
 from lerobot.processor import make_default_processors
@@ -23,7 +23,7 @@ from lerobot.scripts.lerobot_replay import DatasetReplayConfig, ReplayConfig, re
 from lerobot.scripts.lerobot_teleoperate import TeleoperateConfig, teleoperate
 from tests.fixtures.constants import DUMMY_REPO_ID
 from tests.mocks.mock_robot import MockRobot, MockRobotConfig
-from tests.mocks.mock_teleop import MockTeleopConfig
+from tests.mocks.mock_teleop import MockTeleop, MockTeleopConfig
 
 
 def test_calibrate():
@@ -41,6 +41,24 @@ def test_teleoperate():
         teleop_time_s=0.1,
     )
     teleoperate(cfg)
+
+
+def test_teleoperate_skips_send_action_when_teleop_directly_controls_robot():
+    robot_cfg = MockRobotConfig()
+    teleop_cfg = MockTeleopConfig()
+    cfg = TeleoperateConfig(
+        robot=robot_cfg,
+        teleop=teleop_cfg,
+        teleop_time_s=0.1,
+    )
+
+    with (
+        patch.object(MockTeleop, "directly_controls_robot", new_callable=PropertyMock, return_value=True),
+        patch.object(MockRobot, "send_action", autospec=True) as mock_send_action,
+    ):
+        teleoperate(cfg)
+
+    mock_send_action.assert_not_called()
 
 
 def test_record_and_resume(tmp_path):


### PR DESCRIPTION
# 1. "alicia_d_leader" is missing from teleop.type
When using lerobot-teleoperate with Alicia-D Leader and Alicia-M Followe pair. User will see "alicia_d_leader" is a invalid choice. The cause is "alicia_d_leader" is missing from teleop.type in src/lerobot/scripts/lerobot_teleoperate.py. I add it back and created this PR. 

Reproduce command and error message: 

lerobot-teleoperate \
    --robot.type=alicia_m_follower \
    --robot.port=/dev/ttyACM1 \
    --robot.id=alicia_m \
    --teleop.type=alicia_d_leader \
    --teleop.port=/dev/ttyACM0 \
    --teleop.gripper_type=50mm \
    --teleop.directly_controls_robot=false \
    --teleop.target_follower_type=alicia_m \
    --teleop.id=alicia_d
usage: lerobot-teleoperate [-h] [--config_path str] [--teleop str]
                           [--teleop.type {so100_leader,bi_so100_leader,gamepad,homunculus_glove,homunculus_arm,keyboard,keyboard_ee,keyboard_rover,koch_leader,omx_leader,so101_leader}]
                           [--teleop.left_arm_port str] [--teleop.right_arm_port str]
                           [--teleop.side str] [--teleop.baud_rate str] [--teleop.use_gripper str]
                           [--teleop.linear_speed str] [--teleop.angular_speed str]
                           [--teleop.speed_increment str] [--teleop.turn_assist_ratio str]
                           [--teleop.angular_speed_ratio str] [--teleop.min_linear_speed str]
                           [--teleop.min_angular_speed str] [--teleop.gripper_open_pos str]
                           [--teleop.id str] [--teleop.calibration_dir str] [--teleop.port str]
                           [--teleop.use_degrees str] [--robot str]
                           [--robot.type {alicia_d_follower,alicia_m_follower,bi_alicia_d_follower,so100_follower,bi_so100_follower,earthrover_mini_plus,hope_jr_hand,hope_jr_arm,koch_follower,omx_follower,so101_follower}]
                           [--robot.gripper_type str] [--robot.speed_deg_s str] [--robot.version str]
                           [--robot.variant str] [--robot.base_link str] [--robot.end_link str]
                           [--robot.baudrate str] [--robot.control_aim str] [--robot.control_mode str]
                           [--robot.skip_mit_init str] [--robot.use_interpolation str]
                           [--robot.debug_mode str] [--robot.speed str] [--robot.connect_arm str]
                           [--robot.left_arm_connect str] [--robot.left_arm_gripper_type str]
                           [--robot.left_arm_debug_mode str] [--robot.left_arm_speed_deg_s str]
                           [--robot.right_arm_connect str] [--robot.right_arm_gripper_type str]
                           [--robot.right_arm_debug_mode str] [--robot.right_arm_speed_deg_s str]
                           [--robot.use_teleop_state_for_observation str] [--robot.left_arm_port str]
                           [--robot.right_arm_port str]
                           [--robot.left_arm_disable_torque_on_disconnect str]
                           [--robot.left_arm_max_relative_target str]
                           [--robot.left_arm_use_degrees str]
                           [--robot.right_arm_disable_torque_on_disconnect str]
                           [--robot.right_arm_max_relative_target str]
                           [--robot.right_arm_use_degrees str] [--robot.sdk_url str] [--robot.side str]
                           [--robot.id str] [--robot.calibration_dir str] [--robot.port str]
                           [--robot.disable_torque_on_disconnect str] [--robot.max_relative_target str]
                           [--robot.cameras str] [--robot.use_degrees str] [--fps str]
                           [--teleop_time_s str] [--display_data str]
lerobot-teleoperate: error: argument --teleop.type: invalid choice: 'alicia_d_leader' (choose from so100_leader, bi_so100_leader, gamepad, homunculus_glove, homunculus_arm, keyboard, keyboard_ee, keyboard_rover, koch_leader, omx_leader, so101_leader)

#2. "teleop.directly_controls_robot" support is missing from lerobot-teleoperate
When use lerobot-teleoperate without "--teleop.directly_controls_robot" flag or with "teleop.directly_controls_robot=true". The teleoperator controls the robot through the direct hardware connection, sending the action again from the computer would duplicate the command, but lerobot-teleoperate isn't implemented to skip the transmission to respect the flag. The commit add the implementation to lerobot-teleoperate.py